### PR TITLE
お問合せフォームをスニペットを見て修正しました！

### DIFF
--- a/src/public/complete.php
+++ b/src/public/complete.php
@@ -1,8 +1,8 @@
 <?php
 
-$title =  $_POST["title"];
-$email = $_POST["email"];
-$content = $_POST["content"];
+$title = filter_input(INPUT_POST, 'title');
+$email = filter_input(INPUT_POST, 'email');
+$content = filter_input(INPUT_POST, 'content');
 
 $errors = [];
 if (empty($title)||empty($email)||empty($content)) {

--- a/src/public/history.php
+++ b/src/public/history.php
@@ -10,29 +10,27 @@ $statement->execute();
 $contacts = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
-
 <!DOCTYPE html>
 <html lang="ja">
-<font size="5"><b>送信履歴</b></font><br><br><br>
 
-</html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>送信履歴</title>
+</head>
 
-<?php
-foreach ($contacts as $contact) {
-    echo $contact['title'] . "<br>";
-    echo $contact['content'] . "<br>";
-    echo "-----------------------------------------------" . "<br>";
-}
-if (empty($contact)) {
-  echo "送信履歴はありません。";
-}
-
-?>
-
-<!DOCTYPE html>
-<html lang="ja">
-<form action="index.php" method="post">
-  <br><a href="index.php">戻る</a>
-</form>
+<body>
+  <div class="container">
+    <h2>送信履歴</h2>
+    <?php foreach ($contacts as $contact): ?>
+    <h3 class="color: blue;"><?php echo $contact['title']; ?></h3>
+    <p><?php echo $contact['content'] .
+            '<br>' .
+            '----------------------------------------------------------------------'; ?></p>
+    <?php endforeach; ?>
+    <a href="./index.php">戻る</a>
+  </div>
+</body>
 
 </html>

--- a/src/public/history.php
+++ b/src/public/history.php
@@ -10,6 +10,19 @@ $statement->execute();
 $contacts = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
+
+<?php
+// foreach ($contacts as $contact) {
+//     echo $contact['title'] . "<br>";
+//     echo $contact['content'] . "<br>";
+//     echo "-----------------------------------------------" . "<br>";
+// }
+// if (empty($contact)) {
+//   echo "送信履歴はありません。";
+// }
+
+?>
+
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -29,6 +42,9 @@ $contacts = $statement->fetchAll(PDO::FETCH_ASSOC);
             '<br>' .
             '----------------------------------------------------------------------'; ?></p>
     <?php endforeach; ?>
+    <?php if (empty($contact)): ?>
+    <?php echo "送信履歴はありません。"; ?>
+    <?php endif; ?><br>
     <a href="./index.php">戻る</a>
   </div>
 </body>

--- a/src/public/history.php
+++ b/src/public/history.php
@@ -11,18 +11,6 @@ $contacts = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
 
-<?php
-// foreach ($contacts as $contact) {
-//     echo $contact['title'] . "<br>";
-//     echo $contact['content'] . "<br>";
-//     echo "-----------------------------------------------" . "<br>";
-// }
-// if (empty($contact)) {
-//   echo "送信履歴はありません。";
-// }
-
-?>
-
 <!DOCTYPE html>
 <html lang="ja">
 


### PR DESCRIPTION
お疲れ様です！
お問合せフォームをスニペットを見ながら修正しました！
お手隙の際にご確認のほどよろしくお願いいたします！
<img width="347" alt="スクリーンショット 2022-09-29 20 34 12" src="https://user-images.githubusercontent.com/100771427/193020959-f3786b3f-2fa0-46d9-9823-381e6a251f10.png">

◇complete.php
$title =  $_POST["title"];
$email = $_POST["email"];
$content = $_POST["content"];
から
$title = filter_input(INPUT_POST, 'title');
$email = filter_input(INPUT_POST, 'email');
$content = filter_input(INPUT_POST, 'content');
に変更した理由としては、変数に値が入っていなかった時にブラウザ上にエラー文を表示しなくするためです。

◇history.php
最初はPHPでforeachを主力していましたが、HTMLに埋め込む事によって文字サイズや色等を編集できて便利なので
こちらに書き換えました。
<img width="535" alt="スクリーンショット 2022-09-29 20 35 15" src="https://user-images.githubusercontent.com/100771427/193021152-51da0521-b26a-40c2-991b-546e33982cb5.png">
<img width="234" alt="スクリーンショット 2022-09-29 20 37 39" src="https://user-images.githubusercontent.com/100771427/193021586-4c6249d0-b80d-4f9f-878f-27ee4b3abb7b.png">
<img width="470" alt="スクリーンショット 2022-09-29 20 38 04" src="https://user-images.githubusercontent.com/100771427/193021645-f166cef3-9cb0-4773-8c16-e340a5ca1063.png">
<img width="581" alt="スクリーンショット 2022-09-29 20 49 26" src="https://user-images.githubusercontent.com/100771427/193023721-4be2aa21-3c31-4e4b-ba17-09d9cc1629d2.png">
<img width="225" alt="スクリーンショット 2022-09-29 20 51 44" src="https://user-images.githubusercontent.com/100771427/193024146-942d4bd2-10e9-4440-9a33-94db6025d310.png">


